### PR TITLE
ci: Refactor workflow trigger conditions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,16 @@
 # File: ci.yaml
 
-name: Continuous Integration
+name: ci
 
 on:
   push:
-  workflow_call:
+    branches:
+      - '*'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
- Changed the workflow name to 'ci'
- Updated the trigger conditions for push event to include all branches
  and tags starting with 'v'
- Updated trigger conditions for pull requests to only include the 'main'
  branch.